### PR TITLE
회원가입 - 세종대 로그인, 닉네임 입력, 학점 입력

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ iOSInjectionProject/
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode,swift,cocoapods,macos
+
+*.xcconfig

--- a/RankIn/Podfile
+++ b/RankIn/Podfile
@@ -9,6 +9,7 @@ target 'RankIn' do
   pod 'RxSwift'
   pod 'RxCocoa'
   pod 'Alamofire'
+  pod 'Toast-Swift'
 
   # Pods for RankIn
 

--- a/RankIn/Podfile.lock
+++ b/RankIn/Podfile.lock
@@ -7,12 +7,14 @@ PODS:
     - RxSwift (= 6.6.0)
   - RxSwift (6.6.0)
   - SwiftLint (0.54.0)
+  - Toast-Swift (5.1.1)
 
 DEPENDENCIES:
   - Alamofire
   - RxCocoa
   - RxSwift
   - SwiftLint
+  - Toast-Swift
 
 SPEC REPOS:
   trunk:
@@ -21,6 +23,7 @@ SPEC REPOS:
     - RxRelay
     - RxSwift
     - SwiftLint
+    - Toast-Swift
 
 SPEC CHECKSUMS:
   Alamofire: 02b772c9910e8eba1a079227c32fbd9e46c90a24
@@ -28,7 +31,8 @@ SPEC CHECKSUMS:
   RxRelay: 45eaa5db8ee4fb50e5ebd57deec0159e97fa51e6
   RxSwift: a4b44f7d24599f674deebd1818eab82e58410632
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
+  Toast-Swift: 7a03a532afe3a560d4044bc7c237e2864d295173
 
-PODFILE CHECKSUM: 46649a8f9d378e9bade5b456885f7c3cf9481252
+PODFILE CHECKSUM: 20268ecdae87ef51567e17324d317c3ee622c0c4
 
 COCOAPODS: 1.15.2

--- a/RankIn/RankIn.xcodeproj/project.pbxproj
+++ b/RankIn/RankIn.xcodeproj/project.pbxproj
@@ -45,6 +45,16 @@
 		591C46A42BBEF60400D3BF14 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A32BBEF60400D3BF14 /* AuthManager.swift */; };
 		591C46AA2BC136C600D3BF14 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A92BC136C600D3BF14 /* MyPageViewController.swift */; };
 		596A58B52BC9A210006C3108 /* LoginResultDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58B42BC9A210006C3108 /* LoginResultDTO.swift */; };
+		596A58B92BC9A3A2006C3108 /* SejongLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58B82BC9A3A2006C3108 /* SejongLoginViewController.swift */; };
+		596A58BC2BC9B2BF006C3108 /* SejongLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58BB2BC9B2BF006C3108 /* SejongLoginViewModel.swift */; };
+		596A58BF2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58BE2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift */; };
+		596A58C12BC9B5C7006C3108 /* SejongLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58C02BC9B5C7006C3108 /* SejongLoginUseCase.swift */; };
+		596A58C32BC9B60C006C3108 /* SignUpRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58C22BC9B60C006C3108 /* SignUpRepository.swift */; };
+		596A58C72BC9B700006C3108 /* SejongLoginInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58C62BC9B700006C3108 /* SejongLoginInfo.swift */; };
+		596A58C92BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58C82BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift */; };
+		596A58CB2BC9BC5A006C3108 /* DefaultSignUpRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58CA2BC9BC5A006C3108 /* DefaultSignUpRepository.swift */; };
+		596A58CD2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58CC2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift */; };
+		596A58CF2BC9BDD3006C3108 /* SejongLoginResultDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58CE2BC9BDD3006C3108 /* SejongLoginResultDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -92,6 +102,16 @@
 		591C46A92BC136C600D3BF14 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		596A58B32BC83704006C3108 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		596A58B42BC9A210006C3108 /* LoginResultDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResultDTO.swift; sourceTree = "<group>"; };
+		596A58B82BC9A3A2006C3108 /* SejongLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SejongLoginViewController.swift; sourceTree = "<group>"; };
+		596A58BB2BC9B2BF006C3108 /* SejongLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SejongLoginViewModel.swift; sourceTree = "<group>"; };
+		596A58BE2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSejongLoginViewModel.swift; sourceTree = "<group>"; };
+		596A58C02BC9B5C7006C3108 /* SejongLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SejongLoginUseCase.swift; path = ../../../../../../Downloads/SejongLoginUseCase.swift; sourceTree = "<group>"; };
+		596A58C22BC9B60C006C3108 /* SignUpRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpRepository.swift; sourceTree = "<group>"; };
+		596A58C62BC9B700006C3108 /* SejongLoginInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SejongLoginInfo.swift; sourceTree = "<group>"; };
+		596A58C82BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSejongLoginUseCase.swift; sourceTree = "<group>"; };
+		596A58CA2BC9BC5A006C3108 /* DefaultSignUpRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignUpRepository.swift; sourceTree = "<group>"; };
+		596A58CC2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SejongLoginInfoDTO.swift; sourceTree = "<group>"; };
+		596A58CE2BC9BDD3006C3108 /* SejongLoginResultDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SejongLoginResultDTO.swift; sourceTree = "<group>"; };
 		639A6E866D0594E693CF81EA /* Pods-RankIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RankIn.debug.xcconfig"; path = "Target Support Files/Pods-RankIn/Pods-RankIn.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -164,6 +184,7 @@
 		590E9D4D2BAB3F6C006CC09E /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				596A58B62BC9A38C006C3108 /* SignUp */,
 				591C46A72BC136A500D3BF14 /* MyPage */,
 				591C46682BB4431500D3BF14 /* Login */,
 				590E9D6C2BAC86E8006CC09E /* Home */,
@@ -287,6 +308,7 @@
 			children = (
 				591C46842BB8701A00D3BF14 /* AppleLoginModel.swift */,
 				591C468E2BB8750F00D3BF14 /* JWT.swift */,
+				596A58C62BC9B700006C3108 /* SejongLoginInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -297,6 +319,8 @@
 				591C46822BB86AC500D3BF14 /* AppleLoginDTO.swift */,
 				591C468C2BB8749E00D3BF14 /* JWTDTO.swift */,
 				596A58B42BC9A210006C3108 /* LoginResultDTO.swift */,
+				596A58CC2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift */,
+				596A58CE2BC9BDD3006C3108 /* SejongLoginResultDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -305,6 +329,7 @@
 			isa = PBXGroup;
 			children = (
 				591C46882BB8732C00D3BF14 /* DefaultAppleLoginUseCase.swift */,
+				596A58C82BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -314,6 +339,7 @@
 			children = (
 				591C46952BB87B6F00D3BF14 /* Repository */,
 				591C468A2BB8738200D3BF14 /* AppleLoginUseCase.swift */,
+				596A58C02BC9B5C7006C3108 /* SejongLoginUseCase.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -330,6 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				591C46982BB87C6E00D3BF14 /* DefaultLoginRepository.swift */,
+				596A58CA2BC9BC5A006C3108 /* DefaultSignUpRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -338,6 +365,7 @@
 			isa = PBXGroup;
 			children = (
 				591C46962BB87BA300D3BF14 /* LoginRepository.swift */,
+				596A58C22BC9B60C006C3108 /* SignUpRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -372,6 +400,40 @@
 				591C46A92BC136C600D3BF14 /* MyPageViewController.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		596A58B62BC9A38C006C3108 /* SignUp */ = {
+			isa = PBXGroup;
+			children = (
+				596A58BA2BC9B2B7006C3108 /* ViewModel */,
+				596A58B72BC9A395006C3108 /* View */,
+			);
+			path = SignUp;
+			sourceTree = "<group>";
+		};
+		596A58B72BC9A395006C3108 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				596A58B82BC9A3A2006C3108 /* SejongLoginViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		596A58BA2BC9B2B7006C3108 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				596A58BD2BC9B368006C3108 /* Protocol */,
+				596A58BE2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		596A58BD2BC9B368006C3108 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				596A58BB2BC9B2BF006C3108 /* SejongLoginViewModel.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		CE384C7C00B8659705E3FD80 /* Frameworks */ = {
@@ -526,16 +588,25 @@
 			buildActionMask = 2147483647;
 			files = (
 				591C46AA2BC136C600D3BF14 /* MyPageViewController.swift in Sources */,
+				596A58C92BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift in Sources */,
 				591C46782BB859E300D3BF14 /* Router.swift in Sources */,
 				591C46A42BBEF60400D3BF14 /* AuthManager.swift in Sources */,
 				591C46922BB8777400D3BF14 /* LoginViewModel.swift in Sources */,
 				596A58B52BC9A210006C3108 /* LoginResultDTO.swift in Sources */,
 				591C466A2BB4434200D3BF14 /* LoginViewController.swift in Sources */,
+				596A58CB2BC9BC5A006C3108 /* DefaultSignUpRepository.swift in Sources */,
+				596A58C32BC9B60C006C3108 /* SignUpRepository.swift in Sources */,
+				596A58C72BC9B700006C3108 /* SejongLoginInfo.swift in Sources */,
+				596A58B92BC9A3A2006C3108 /* SejongLoginViewController.swift in Sources */,
 				591C46832BB86AC500D3BF14 /* AppleLoginDTO.swift in Sources */,
 				591C46852BB8701A00D3BF14 /* AppleLoginModel.swift in Sources */,
 				591C469C2BB9AEAE00D3BF14 /* Encodable+AsDictionary.swift in Sources */,
 				591C46972BB87BA300D3BF14 /* LoginRepository.swift in Sources */,
+				596A58C12BC9B5C7006C3108 /* SejongLoginUseCase.swift in Sources */,
+				596A58CD2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift in Sources */,
 				590E9D662BAB46CC006CC09E /* UIFont+Pretendard.swift in Sources */,
+				596A58BF2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift in Sources */,
+				596A58CF2BC9BDD3006C3108 /* SejongLoginResultDTO.swift in Sources */,
 				591C46742BB4815600D3BF14 /* UIImage+SystemImage.swift in Sources */,
 				591C46892BB8732C00D3BF14 /* DefaultAppleLoginUseCase.swift in Sources */,
 				591C468B2BB8738200D3BF14 /* AppleLoginUseCase.swift in Sources */,
@@ -544,6 +615,7 @@
 				590E9D6E2BAC8703006CC09E /* SplashAnimationView.swift in Sources */,
 				591C468D2BB8749E00D3BF14 /* JWTDTO.swift in Sources */,
 				590E9D392BAB3D0C006CC09E /* AppDelegate.swift in Sources */,
+				596A58BC2BC9B2BF006C3108 /* SejongLoginViewModel.swift in Sources */,
 				590E9D3B2BAB3D0C006CC09E /* SceneDelegate.swift in Sources */,
 				590E9D502BAB4018006CC09E /* SplashViewController.swift in Sources */,
 				591C46992BB87C6E00D3BF14 /* DefaultLoginRepository.swift in Sources */,

--- a/RankIn/RankIn.xcodeproj/project.pbxproj
+++ b/RankIn/RankIn.xcodeproj/project.pbxproj
@@ -55,6 +55,11 @@
 		596A58CB2BC9BC5A006C3108 /* DefaultSignUpRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58CA2BC9BC5A006C3108 /* DefaultSignUpRepository.swift */; };
 		596A58CD2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58CC2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift */; };
 		596A58CF2BC9BDD3006C3108 /* SejongLoginResultDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58CE2BC9BDD3006C3108 /* SejongLoginResultDTO.swift */; };
+		596A58D12BCAD51D006C3108 /* NicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D02BCAD51D006C3108 /* NicknameViewController.swift */; };
+		596A58D32BCAD616006C3108 /* NicknameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D22BCAD615006C3108 /* NicknameViewModel.swift */; };
+		596A58D52BCAD66B006C3108 /* SetNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D42BCAD66B006C3108 /* SetNicknameUseCase.swift */; };
+		596A58D72BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D62BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift */; };
+		596A58D92BCADAC3006C3108 /* DefaultNicknameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -112,6 +117,11 @@
 		596A58CA2BC9BC5A006C3108 /* DefaultSignUpRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignUpRepository.swift; sourceTree = "<group>"; };
 		596A58CC2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SejongLoginInfoDTO.swift; sourceTree = "<group>"; };
 		596A58CE2BC9BDD3006C3108 /* SejongLoginResultDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SejongLoginResultDTO.swift; sourceTree = "<group>"; };
+		596A58D02BCAD51D006C3108 /* NicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewController.swift; sourceTree = "<group>"; };
+		596A58D22BCAD615006C3108 /* NicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewModel.swift; sourceTree = "<group>"; };
+		596A58D42BCAD66B006C3108 /* SetNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNicknameUseCase.swift; sourceTree = "<group>"; };
+		596A58D62BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSetNicknameUseCase.swift; sourceTree = "<group>"; };
+		596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNicknameViewModel.swift; sourceTree = "<group>"; };
 		639A6E866D0594E693CF81EA /* Pods-RankIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RankIn.debug.xcconfig"; path = "Target Support Files/Pods-RankIn/Pods-RankIn.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -330,6 +340,7 @@
 			children = (
 				591C46882BB8732C00D3BF14 /* DefaultAppleLoginUseCase.swift */,
 				596A58C82BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift */,
+				596A58D62BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -340,6 +351,7 @@
 				591C46952BB87B6F00D3BF14 /* Repository */,
 				591C468A2BB8738200D3BF14 /* AppleLoginUseCase.swift */,
 				596A58C02BC9B5C7006C3108 /* SejongLoginUseCase.swift */,
+				596A58D42BCAD66B006C3108 /* SetNicknameUseCase.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -405,8 +417,8 @@
 		596A58B62BC9A38C006C3108 /* SignUp */ = {
 			isa = PBXGroup;
 			children = (
-				596A58BA2BC9B2B7006C3108 /* ViewModel */,
 				596A58B72BC9A395006C3108 /* View */,
+				596A58BA2BC9B2B7006C3108 /* ViewModel */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -415,6 +427,7 @@
 			isa = PBXGroup;
 			children = (
 				596A58B82BC9A3A2006C3108 /* SejongLoginViewController.swift */,
+				596A58D02BCAD51D006C3108 /* NicknameViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -424,6 +437,7 @@
 			children = (
 				596A58BD2BC9B368006C3108 /* Protocol */,
 				596A58BE2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift */,
+				596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -432,6 +446,7 @@
 			isa = PBXGroup;
 			children = (
 				596A58BB2BC9B2BF006C3108 /* SejongLoginViewModel.swift */,
+				596A58D22BCAD615006C3108 /* NicknameViewModel.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -591,17 +606,21 @@
 				596A58C92BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift in Sources */,
 				591C46782BB859E300D3BF14 /* Router.swift in Sources */,
 				591C46A42BBEF60400D3BF14 /* AuthManager.swift in Sources */,
+				596A58D52BCAD66B006C3108 /* SetNicknameUseCase.swift in Sources */,
 				591C46922BB8777400D3BF14 /* LoginViewModel.swift in Sources */,
 				596A58B52BC9A210006C3108 /* LoginResultDTO.swift in Sources */,
 				591C466A2BB4434200D3BF14 /* LoginViewController.swift in Sources */,
 				596A58CB2BC9BC5A006C3108 /* DefaultSignUpRepository.swift in Sources */,
 				596A58C32BC9B60C006C3108 /* SignUpRepository.swift in Sources */,
 				596A58C72BC9B700006C3108 /* SejongLoginInfo.swift in Sources */,
+				596A58D12BCAD51D006C3108 /* NicknameViewController.swift in Sources */,
 				596A58B92BC9A3A2006C3108 /* SejongLoginViewController.swift in Sources */,
 				591C46832BB86AC500D3BF14 /* AppleLoginDTO.swift in Sources */,
 				591C46852BB8701A00D3BF14 /* AppleLoginModel.swift in Sources */,
 				591C469C2BB9AEAE00D3BF14 /* Encodable+AsDictionary.swift in Sources */,
 				591C46972BB87BA300D3BF14 /* LoginRepository.swift in Sources */,
+				596A58D32BCAD616006C3108 /* NicknameViewModel.swift in Sources */,
+				596A58D72BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift in Sources */,
 				596A58C12BC9B5C7006C3108 /* SejongLoginUseCase.swift in Sources */,
 				596A58CD2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift in Sources */,
 				590E9D662BAB46CC006CC09E /* UIFont+Pretendard.swift in Sources */,
@@ -613,6 +632,7 @@
 				591C46A22BBDB99700D3BF14 /* KeyChainManager.swift in Sources */,
 				590E9D3D2BAB3D0C006CC09E /* HomeViewController.swift in Sources */,
 				590E9D6E2BAC8703006CC09E /* SplashAnimationView.swift in Sources */,
+				596A58D92BCADAC3006C3108 /* DefaultNicknameViewModel.swift in Sources */,
 				591C468D2BB8749E00D3BF14 /* JWTDTO.swift in Sources */,
 				590E9D392BAB3D0C006CC09E /* AppDelegate.swift in Sources */,
 				596A58BC2BC9B2BF006C3108 /* SejongLoginViewModel.swift in Sources */,

--- a/RankIn/RankIn.xcodeproj/project.pbxproj
+++ b/RankIn/RankIn.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		596A58D52BCAD66B006C3108 /* SetNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D42BCAD66B006C3108 /* SetNicknameUseCase.swift */; };
 		596A58D72BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D62BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift */; };
 		596A58D92BCADAC3006C3108 /* DefaultNicknameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */; };
+		59A2BADE2BCECD80003CFCAA /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BADD2BCECD80003CFCAA /* RepositoryError.swift */; };
+		59A2BAE02BCED306003CFCAA /* UIViewController+Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BADF2BCED306003CFCAA /* UIViewController+Toast.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -122,6 +124,8 @@
 		596A58D42BCAD66B006C3108 /* SetNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNicknameUseCase.swift; sourceTree = "<group>"; };
 		596A58D62BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSetNicknameUseCase.swift; sourceTree = "<group>"; };
 		596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNicknameViewModel.swift; sourceTree = "<group>"; };
+		59A2BADD2BCECD80003CFCAA /* RepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryError.swift; sourceTree = "<group>"; };
+		59A2BADF2BCED306003CFCAA /* UIViewController+Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Toast.swift"; sourceTree = "<group>"; };
 		639A6E866D0594E693CF81EA /* Pods-RankIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RankIn.debug.xcconfig"; path = "Target Support Files/Pods-RankIn/Pods-RankIn.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -233,6 +237,7 @@
 			children = (
 				590E9D652BAB46CC006CC09E /* UIFont+Pretendard.swift */,
 				591C46732BB4815600D3BF14 /* UIImage+SystemImage.swift */,
+				59A2BADF2BCED306003CFCAA /* UIViewController+Toast.swift */,
 			);
 			path = extension;
 			sourceTree = "<group>";
@@ -293,6 +298,7 @@
 		591C46762BB859D300D3BF14 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				59A2BADC2BCECD6B003CFCAA /* Error */,
 				591C469A2BB9AE9E00D3BF14 /* Extension */,
 				591C46812BB86AA200D3BF14 /* DTO */,
 				591C46772BB859E300D3BF14 /* Router.swift */,
@@ -451,6 +457,14 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		59A2BADC2BCECD6B003CFCAA /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				59A2BADD2BCECD80003CFCAA /* RepositoryError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		CE384C7C00B8659705E3FD80 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -602,6 +616,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59A2BAE02BCED306003CFCAA /* UIViewController+Toast.swift in Sources */,
 				591C46AA2BC136C600D3BF14 /* MyPageViewController.swift in Sources */,
 				596A58C92BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift in Sources */,
 				591C46782BB859E300D3BF14 /* Router.swift in Sources */,
@@ -628,6 +643,7 @@
 				596A58CF2BC9BDD3006C3108 /* SejongLoginResultDTO.swift in Sources */,
 				591C46742BB4815600D3BF14 /* UIImage+SystemImage.swift in Sources */,
 				591C46892BB8732C00D3BF14 /* DefaultAppleLoginUseCase.swift in Sources */,
+				59A2BADE2BCECD80003CFCAA /* RepositoryError.swift in Sources */,
 				591C468B2BB8738200D3BF14 /* AppleLoginUseCase.swift in Sources */,
 				591C46A22BBDB99700D3BF14 /* KeyChainManager.swift in Sources */,
 				590E9D3D2BAB3D0C006CC09E /* HomeViewController.swift in Sources */,

--- a/RankIn/RankIn.xcodeproj/project.pbxproj
+++ b/RankIn/RankIn.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		591C469C2BB9AEAE00D3BF14 /* Encodable+AsDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C469B2BB9AEAE00D3BF14 /* Encodable+AsDictionary.swift */; };
 		591C46A22BBDB99700D3BF14 /* KeyChainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A12BBDB99700D3BF14 /* KeyChainManager.swift */; };
 		591C46A42BBEF60400D3BF14 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A32BBEF60400D3BF14 /* AuthManager.swift */; };
+		591C46AA2BC136C600D3BF14 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A92BC136C600D3BF14 /* MyPageViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -87,6 +88,8 @@
 		591C469B2BB9AEAE00D3BF14 /* Encodable+AsDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+AsDictionary.swift"; sourceTree = "<group>"; };
 		591C46A12BBDB99700D3BF14 /* KeyChainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainManager.swift; sourceTree = "<group>"; };
 		591C46A32BBEF60400D3BF14 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		591C46A92BC136C600D3BF14 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
+		596A58B32BC83704006C3108 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		639A6E866D0594E693CF81EA /* Pods-RankIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RankIn.debug.xcconfig"; path = "Target Support Files/Pods-RankIn/Pods-RankIn.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -114,6 +117,7 @@
 		590E9D2C2BAB3D0C006CC09E = {
 			isa = PBXGroup;
 			children = (
+				596A58B32BC83704006C3108 /* Secret.xcconfig */,
 				590E9D682BAC70A9006CC09E /* .swiftlint.yml */,
 				590E9D372BAB3D0C006CC09E /* RankIn */,
 				590E9D362BAB3D0C006CC09E /* Products */,
@@ -158,6 +162,7 @@
 		590E9D4D2BAB3F6C006CC09E /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				591C46A72BC136A500D3BF14 /* MyPage */,
 				591C46682BB4431500D3BF14 /* Login */,
 				590E9D6C2BAC86E8006CC09E /* Home */,
 				590E9D692BAC86D7006CC09E /* Splash */,
@@ -350,6 +355,22 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		591C46A72BC136A500D3BF14 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				591C46A82BC136B100D3BF14 /* View */,
+			);
+			path = MyPage;
+			sourceTree = "<group>";
+		};
+		591C46A82BC136B100D3BF14 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				591C46A92BC136C600D3BF14 /* MyPageViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		CE384C7C00B8659705E3FD80 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -501,6 +522,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				591C46AA2BC136C600D3BF14 /* MyPageViewController.swift in Sources */,
 				591C46782BB859E300D3BF14 /* Router.swift in Sources */,
 				591C46A42BBEF60400D3BF14 /* AuthManager.swift in Sources */,
 				591C46922BB8777400D3BF14 /* LoginViewModel.swift in Sources */,
@@ -544,6 +566,7 @@
 /* Begin XCBuildConfiguration section */
 		590E9D472BAB3D0E006CC09E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 596A58B32BC83704006C3108 /* Secret.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/RankIn/RankIn.xcodeproj/project.pbxproj
+++ b/RankIn/RankIn.xcodeproj/project.pbxproj
@@ -62,6 +62,11 @@
 		596A58D92BCADAC3006C3108 /* DefaultNicknameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */; };
 		59A2BADE2BCECD80003CFCAA /* RepositoryError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BADD2BCECD80003CFCAA /* RepositoryError.swift */; };
 		59A2BAE02BCED306003CFCAA /* UIViewController+Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BADF2BCED306003CFCAA /* UIViewController+Toast.swift */; };
+		59A2BAE42BCED616003CFCAA /* GradeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BAE32BCED616003CFCAA /* GradeViewController.swift */; };
+		59A2BAE62BCED70B003CFCAA /* GradeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BAE52BCED70B003CFCAA /* GradeViewModel.swift */; };
+		59A2BAE82BCED764003CFCAA /* SetGradeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BAE72BCED764003CFCAA /* SetGradeUseCase.swift */; };
+		59A2BAEA2BCED7A8003CFCAA /* DefaultSetGradeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BAE92BCED7A8003CFCAA /* DefaultSetGradeUseCase.swift */; };
+		59A2BAEC2BCED8DA003CFCAA /* DefaultGradeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A2BAEB2BCED8DA003CFCAA /* DefaultGradeViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -126,6 +131,11 @@
 		596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNicknameViewModel.swift; sourceTree = "<group>"; };
 		59A2BADD2BCECD80003CFCAA /* RepositoryError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryError.swift; sourceTree = "<group>"; };
 		59A2BADF2BCED306003CFCAA /* UIViewController+Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Toast.swift"; sourceTree = "<group>"; };
+		59A2BAE32BCED616003CFCAA /* GradeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeViewController.swift; sourceTree = "<group>"; };
+		59A2BAE52BCED70B003CFCAA /* GradeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeViewModel.swift; sourceTree = "<group>"; };
+		59A2BAE72BCED764003CFCAA /* SetGradeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetGradeUseCase.swift; sourceTree = "<group>"; };
+		59A2BAE92BCED7A8003CFCAA /* DefaultSetGradeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSetGradeUseCase.swift; sourceTree = "<group>"; };
+		59A2BAEB2BCED8DA003CFCAA /* DefaultGradeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGradeViewModel.swift; sourceTree = "<group>"; };
 		639A6E866D0594E693CF81EA /* Pods-RankIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RankIn.debug.xcconfig"; path = "Target Support Files/Pods-RankIn/Pods-RankIn.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -347,6 +357,7 @@
 				591C46882BB8732C00D3BF14 /* DefaultAppleLoginUseCase.swift */,
 				596A58C82BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift */,
 				596A58D62BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift */,
+				59A2BAE92BCED7A8003CFCAA /* DefaultSetGradeUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -358,6 +369,7 @@
 				591C468A2BB8738200D3BF14 /* AppleLoginUseCase.swift */,
 				596A58C02BC9B5C7006C3108 /* SejongLoginUseCase.swift */,
 				596A58D42BCAD66B006C3108 /* SetNicknameUseCase.swift */,
+				59A2BAE72BCED764003CFCAA /* SetGradeUseCase.swift */,
 			);
 			path = Interface;
 			sourceTree = "<group>";
@@ -434,6 +446,7 @@
 			children = (
 				596A58B82BC9A3A2006C3108 /* SejongLoginViewController.swift */,
 				596A58D02BCAD51D006C3108 /* NicknameViewController.swift */,
+				59A2BAE32BCED616003CFCAA /* GradeViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -444,6 +457,7 @@
 				596A58BD2BC9B368006C3108 /* Protocol */,
 				596A58BE2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift */,
 				596A58D82BCADAC2006C3108 /* DefaultNicknameViewModel.swift */,
+				59A2BAEB2BCED8DA003CFCAA /* DefaultGradeViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -453,6 +467,7 @@
 			children = (
 				596A58BB2BC9B2BF006C3108 /* SejongLoginViewModel.swift */,
 				596A58D22BCAD615006C3108 /* NicknameViewModel.swift */,
+				59A2BAE52BCED70B003CFCAA /* GradeViewModel.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -616,6 +631,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59A2BAEA2BCED7A8003CFCAA /* DefaultSetGradeUseCase.swift in Sources */,
 				59A2BAE02BCED306003CFCAA /* UIViewController+Toast.swift in Sources */,
 				591C46AA2BC136C600D3BF14 /* MyPageViewController.swift in Sources */,
 				596A58C92BC9BBEF006C3108 /* DefaultSejongLoginUseCase.swift in Sources */,
@@ -626,6 +642,7 @@
 				596A58B52BC9A210006C3108 /* LoginResultDTO.swift in Sources */,
 				591C466A2BB4434200D3BF14 /* LoginViewController.swift in Sources */,
 				596A58CB2BC9BC5A006C3108 /* DefaultSignUpRepository.swift in Sources */,
+				59A2BAE82BCED764003CFCAA /* SetGradeUseCase.swift in Sources */,
 				596A58C32BC9B60C006C3108 /* SignUpRepository.swift in Sources */,
 				596A58C72BC9B700006C3108 /* SejongLoginInfo.swift in Sources */,
 				596A58D12BCAD51D006C3108 /* NicknameViewController.swift in Sources */,
@@ -637,7 +654,10 @@
 				596A58D32BCAD616006C3108 /* NicknameViewModel.swift in Sources */,
 				596A58D72BCAD6B8006C3108 /* DefaultSetNicknameUseCase.swift in Sources */,
 				596A58C12BC9B5C7006C3108 /* SejongLoginUseCase.swift in Sources */,
+				59A2BAE62BCED70B003CFCAA /* GradeViewModel.swift in Sources */,
 				596A58CD2BC9BCC8006C3108 /* SejongLoginInfoDTO.swift in Sources */,
+				59A2BAE42BCED616003CFCAA /* GradeViewController.swift in Sources */,
+				59A2BAEC2BCED8DA003CFCAA /* DefaultGradeViewModel.swift in Sources */,
 				590E9D662BAB46CC006CC09E /* UIFont+Pretendard.swift in Sources */,
 				596A58BF2BC9B37C006C3108 /* DefaultSejongLoginViewModel.swift in Sources */,
 				596A58CF2BC9BDD3006C3108 /* SejongLoginResultDTO.swift in Sources */,

--- a/RankIn/RankIn.xcodeproj/project.pbxproj
+++ b/RankIn/RankIn.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		591C46A22BBDB99700D3BF14 /* KeyChainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A12BBDB99700D3BF14 /* KeyChainManager.swift */; };
 		591C46A42BBEF60400D3BF14 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A32BBEF60400D3BF14 /* AuthManager.swift */; };
 		591C46AA2BC136C600D3BF14 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591C46A92BC136C600D3BF14 /* MyPageViewController.swift */; };
+		596A58B52BC9A210006C3108 /* LoginResultDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596A58B42BC9A210006C3108 /* LoginResultDTO.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,6 +91,7 @@
 		591C46A32BBEF60400D3BF14 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		591C46A92BC136C600D3BF14 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		596A58B32BC83704006C3108 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
+		596A58B42BC9A210006C3108 /* LoginResultDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResultDTO.swift; sourceTree = "<group>"; };
 		639A6E866D0594E693CF81EA /* Pods-RankIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RankIn.debug.xcconfig"; path = "Target Support Files/Pods-RankIn/Pods-RankIn.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -294,6 +296,7 @@
 			children = (
 				591C46822BB86AC500D3BF14 /* AppleLoginDTO.swift */,
 				591C468C2BB8749E00D3BF14 /* JWTDTO.swift */,
+				596A58B42BC9A210006C3108 /* LoginResultDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -526,6 +529,7 @@
 				591C46782BB859E300D3BF14 /* Router.swift in Sources */,
 				591C46A42BBEF60400D3BF14 /* AuthManager.swift in Sources */,
 				591C46922BB8777400D3BF14 /* LoginViewModel.swift in Sources */,
+				596A58B52BC9A210006C3108 /* LoginResultDTO.swift in Sources */,
 				591C466A2BB4434200D3BF14 /* LoginViewController.swift in Sources */,
 				591C46832BB86AC500D3BF14 /* AppleLoginDTO.swift in Sources */,
 				591C46852BB8701A00D3BF14 /* AppleLoginModel.swift in Sources */,

--- a/RankIn/RankIn/Application/Info.plist
+++ b/RankIn/RankIn/Application/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>DEV_SERVER_URL</key>
+	<string>$(DEV_SERVER_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/RankIn/RankIn/Application/SceneDelegate.swift
+++ b/RankIn/RankIn/Application/SceneDelegate.swift
@@ -31,10 +31,36 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let loginViewModel = DefaultLoginViewModel(dependency: loginViewModelDependency)
         
+        let myPageViewController = MyPageViewController()
+        let myPageNavigationController = UINavigationController(rootViewController: myPageViewController)
+        
         let homeViewController = HomeViewController()
+        let homeNavigationController = UINavigationController(rootViewController: homeViewController)
+        
+        let mainTabBarController = UITabBarController()
+        mainTabBarController.modalPresentationStyle = .fullScreen
+        mainTabBarController.modalTransitionStyle = .crossDissolve
+        mainTabBarController.setViewControllers(
+            [
+                homeNavigationController,
+                myPageNavigationController
+            ],
+            animated: true
+        )
+        
+        if let items = mainTabBarController.tabBar.items {
+            items[0].selectedImage = UIImage.systemImage(systemImage: .chartBar)
+            items[0].image = UIImage.systemImage(systemImage: .chartBar)
+            items[0].title = "Rank"
+            
+            items[1].selectedImage = UIImage.systemImage(systemImage: .person)
+            items[1].image = UIImage.systemImage(systemImage: .person)
+            items[1].title = "MyPage"
+        }
+        
         let loginViewController = LoginViewController(
             viewModel: loginViewModel,
-            homeViewController: homeViewController
+            mainTabBarController: mainTabBarController
         )
         
         let splashViewController = SplashViewController(loginViewController: loginViewController)

--- a/RankIn/RankIn/Application/SceneDelegate.swift
+++ b/RankIn/RankIn/Application/SceneDelegate.swift
@@ -26,15 +26,19 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let appleLoginUseCase = DefaultAppleLoginUseCase(repository: loginRepository)
         let sejongLoginUseCase = DefaultSejongLoginUseCase(repository: signUpRepository)
+        let setGradeUseCase = DefaultSetGradeUseCase(repository: signUpRepository)
         
         let loginViewModelDependency = LoginViewModelDependency(
             appleLoginUseCase: appleLoginUseCase
         )
         let sejongLoginViewModelDependency = SejongLoginViewModelDependency(sejongLoginUseCase: sejongLoginUseCase)
-        
+        let gradeViewModelDependency = GradeViewModelDependency(setGradeUseCase: setGradeUseCase)
+
         let loginViewModel = DefaultLoginViewModel(dependency: loginViewModelDependency)
         let sejongLoginViewModel = DefaultSejongLoginViewModel(dependency: sejongLoginViewModelDependency)
+        let gradeViewModel = DefaultGradeViewModel(dependency: gradeViewModelDependency)
         
+        let gradeViewController = GradeViewController(gradeViewModel: gradeViewModel)
         let myPageViewController = MyPageViewController()
         let myPageNavigationController = UINavigationController(rootViewController: myPageViewController)
         
@@ -48,7 +52,8 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                         repository: signUpRepository
                     )
                 )
-            )
+            ),
+            gradeViewController: gradeViewController
         )
         let sejongLoginViewController = SejongLoginViewController(
             sejongLoginViewModel: sejongLoginViewModel, 

--- a/RankIn/RankIn/Application/SceneDelegate.swift
+++ b/RankIn/RankIn/Application/SceneDelegate.swift
@@ -22,20 +22,42 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let loginRepository = DefaultLoginRepository(
             session: AF
         )
+        let signUpRepository = DefaultSignUpRepository(session: AF)
         
         let appleLoginUseCase = DefaultAppleLoginUseCase(repository: loginRepository)
+        let sejongLoginUseCase = DefaultSejongLoginUseCase(repository: signUpRepository)
         
         let loginViewModelDependency = LoginViewModelDependency(
             appleLoginUseCase: appleLoginUseCase
         )
+        let sejongLoginViewModelDependency = SejongLoginViewModelDependency(sejongLoginUseCase: sejongLoginUseCase)
         
         let loginViewModel = DefaultLoginViewModel(dependency: loginViewModelDependency)
+        let sejongLoginViewModel = DefaultSejongLoginViewModel(dependency: sejongLoginViewModelDependency)
         
         let myPageViewController = MyPageViewController()
         let myPageNavigationController = UINavigationController(rootViewController: myPageViewController)
         
         let homeViewController = HomeViewController()
         let homeNavigationController = UINavigationController(rootViewController: homeViewController)
+        
+        let nicknameViewController = NicknameViewController(
+            nicknameViewModel: DefaultNicknameViewModel(
+                dependency: NicknameViewModelDependency(
+                    setNicknameUseCase: DefaultSetNicknameUseCase(
+                        repository: signUpRepository
+                    )
+                )
+            )
+        )
+        let sejongLoginViewController = SejongLoginViewController(
+            sejongLoginViewModel: sejongLoginViewModel, 
+            nicknameViewController: nicknameViewController
+        )
+        
+        let signUpNavigationController = UINavigationController(rootViewController: sejongLoginViewController)
+        signUpNavigationController.modalPresentationStyle = .fullScreen
+        signUpNavigationController.modalTransitionStyle = .crossDissolve
         
         let mainTabBarController = UITabBarController()
         mainTabBarController.modalPresentationStyle = .fullScreen
@@ -60,7 +82,8 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let loginViewController = LoginViewController(
             viewModel: loginViewModel,
-            mainTabBarController: mainTabBarController
+            mainTabBarController: mainTabBarController,
+            signUpNavigationController: signUpNavigationController
         )
         
         let splashViewController = SplashViewController(loginViewController: loginViewController)

--- a/RankIn/RankIn/Data/Network/AuthManager.swift
+++ b/RankIn/RankIn/Data/Network/AuthManager.swift
@@ -36,7 +36,7 @@ final class AuthManager: RequestInterceptor {
         dueTo error: Error,
         completion: @escaping (RetryResult) -> Void
     ) {
-        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 403 else { // TODO: 오류 코드 재확인 필요
             completion(.doNotRetryWithError(error))
             return
         }

--- a/RankIn/RankIn/Data/Network/AuthManager.swift
+++ b/RankIn/RankIn/Data/Network/AuthManager.swift
@@ -60,5 +60,4 @@ final class AuthManager: RequestInterceptor {
             }
     }
     
-    
 }

--- a/RankIn/RankIn/Data/Network/AuthManager.swift
+++ b/RankIn/RankIn/Data/Network/AuthManager.swift
@@ -20,7 +20,7 @@ final class AuthManager: RequestInterceptor {
         for session: Session,
         completion: @escaping (Result<URLRequest, Error>) -> Void
     ) {
-        guard let accessToken = KeyChainManager.read(token: .access) else {
+        guard let accessToken = KeyChainManager.read(storeElement: .accessToken) else {
             completion(.failure(AuthError.noToken))
             return
         }
@@ -41,7 +41,7 @@ final class AuthManager: RequestInterceptor {
             return
         }
         
-        guard let refreshToken = KeyChainManager.read(token: .refresh) else {
+        guard let refreshToken = KeyChainManager.read(storeElement: .refreshToken) else {
             completion(.doNotRetryWithError(error))
             return
         }
@@ -51,8 +51,8 @@ final class AuthManager: RequestInterceptor {
             .responseDecodable(of: JWTDTO.self) { response in
                 switch response.result {
                 case .success(let data):
-                    KeyChainManager.create(token: .access, content: data.accessToken)
-                    KeyChainManager.create(token: .refresh, content: data.refreshToken)
+                    KeyChainManager.create(storeElement: .accessToken, content: data.accessToken)
+                    KeyChainManager.create(storeElement: .refreshToken, content: data.refreshToken)
                     completion(.retry)
                 case .failure(let error):
                     completion(.doNotRetryWithError(error))

--- a/RankIn/RankIn/Data/Network/DTO/LoginResultDTO.swift
+++ b/RankIn/RankIn/Data/Network/DTO/LoginResultDTO.swift
@@ -12,5 +12,6 @@ struct LoginResultDTO: Decodable {
     let accessToken: String
     let refreshToken: String
     let isMember: Bool
+    let userID: Int
     
 }

--- a/RankIn/RankIn/Data/Network/DTO/LoginResultDTO.swift
+++ b/RankIn/RankIn/Data/Network/DTO/LoginResultDTO.swift
@@ -1,0 +1,16 @@
+//
+//  LoginResultDTO.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import Foundation
+
+struct LoginResultDTO: Decodable {
+    
+    let accessToken: String
+    let refreshToken: String
+    let isMember: Bool
+    
+}

--- a/RankIn/RankIn/Data/Network/DTO/SejongLoginInfoDTO.swift
+++ b/RankIn/RankIn/Data/Network/DTO/SejongLoginInfoDTO.swift
@@ -1,0 +1,15 @@
+//
+//  SejongLoginInfoDTO.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import Foundation
+
+struct SejongLoginInfoDTO: Encodable {
+    
+    let id: String
+    let pw: String
+    
+}

--- a/RankIn/RankIn/Data/Network/DTO/SejongLoginResultDTO.swift
+++ b/RankIn/RankIn/Data/Network/DTO/SejongLoginResultDTO.swift
@@ -1,0 +1,15 @@
+//
+//  SejongLoginResultDTO.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import Foundation
+
+struct SejongLoginResultDTO: Decodable {
+    
+    // TODO: isAuthorized로 수정
+    let isSejong: Bool
+    
+}

--- a/RankIn/RankIn/Data/Network/DTO/SejongLoginResultDTO.swift
+++ b/RankIn/RankIn/Data/Network/DTO/SejongLoginResultDTO.swift
@@ -9,7 +9,6 @@ import Foundation
 
 struct SejongLoginResultDTO: Decodable {
     
-    // TODO: isAuthorized로 수정
-    let isSejong: Bool
+    let isAuthorized: Bool
     
 }

--- a/RankIn/RankIn/Data/Network/Error/RepositoryError.swift
+++ b/RankIn/RankIn/Data/Network/Error/RepositoryError.swift
@@ -1,0 +1,14 @@
+//
+//  RepositoryError.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/17/24.
+//
+
+import Foundation
+
+enum RepositoryError: Error {
+    
+    case noUserID
+    
+}

--- a/RankIn/RankIn/Data/Network/RankInAPI.swift
+++ b/RankIn/RankIn/Data/Network/RankInAPI.swift
@@ -14,19 +14,24 @@ enum RankInAPI {
     
 }
 
-// TODO: 실제 API가 나오면 모두 수정
 extension RankInAPI: Router, URLRequestConvertible {
     
     var baseURL: String? {
-        return "https://3641762d-4387-4794-bb6d-ac90b6ffe195.mock.pstmn.io/api/appleOAuth"
+        return getURL()
     }
     
     var path: String {
-        return ""
+        switch self {
+        case .appleLogin(let appleLoginDTO):
+            return "auth/apple"
+        }
     }
     
     var method: HTTPMethod {
-        return .post
+        switch self {
+        case .appleLogin(let appleLoginDTO):
+            return .post
+        }
     }
     
     var headers: [String: String] {
@@ -71,6 +76,15 @@ extension RankInAPI: Router, URLRequestConvertible {
         }
         
         return request
+    }
+    
+}
+
+private extension RankInAPI {
+    
+    func getURL() -> String? {
+        guard let url = Bundle.main.object(forInfoDictionaryKey: "DEV_SERVER_URL") as? String else { return nil }
+        return url
     }
     
 }

--- a/RankIn/RankIn/Data/Network/RankInAPI.swift
+++ b/RankIn/RankIn/Data/Network/RankInAPI.swift
@@ -14,6 +14,7 @@ enum RankInAPI {
     case requestAccessToken(refreshToken: String)
     case sejongLogin(SejongLoginInfoDTO: SejongLoginInfoDTO)
     case setNickname(userID: String, nickname: String)
+    case setGrade(userID: String, grade: String)
     
 }
 
@@ -31,7 +32,7 @@ extension RankInAPI: Router, URLRequestConvertible {
             return "auth/refresh"
         case .sejongLogin:
             return "auth/sejong"
-        case .setNickname(let userID, _):
+        case .setNickname(let userID, _), .setGrade(let userID, _):
             return "users/\(userID)"
         }
     }
@@ -40,7 +41,7 @@ extension RankInAPI: Router, URLRequestConvertible {
         switch self {
         case .appleLogin, .requestAccessToken, .sejongLogin:
             return .post
-        case .setNickname:
+        case .setNickname, .setGrade:
             return .put
         }
     }
@@ -64,12 +65,14 @@ extension RankInAPI: Router, URLRequestConvertible {
             return sejongLoginInfoDTO.asDictionary()
         case .setNickname(_, let nickname):
             return nickname.asDictionary()
+        case .setGrade(_, let grade):
+            return grade.asDictionary()
         }
     }
     
     var encoding: ParameterEncoding? {
         switch self {
-        case .appleLogin, .requestAccessToken, .sejongLogin, .setNickname:
+        case .appleLogin, .requestAccessToken, .sejongLogin, .setNickname, .setGrade:
             return JSONEncoding.default
         }
     }

--- a/RankIn/RankIn/Data/Network/RankInAPI.swift
+++ b/RankIn/RankIn/Data/Network/RankInAPI.swift
@@ -13,6 +13,7 @@ enum RankInAPI {
     case appleLogin(appleLoginDTO: AppleLoginDTO)
     case requestAccessToken(refreshToken: String)
     case sejongLogin(SejongLoginInfoDTO: SejongLoginInfoDTO)
+    case setNickname(userID: String, nickname: String)
     
 }
 
@@ -30,6 +31,8 @@ extension RankInAPI: Router, URLRequestConvertible {
             return "auth/refresh"
         case .sejongLogin:
             return "auth/sejong"
+        case .setNickname(let userID, _):
+            return "users/\(userID)"
         }
     }
     
@@ -37,6 +40,8 @@ extension RankInAPI: Router, URLRequestConvertible {
         switch self {
         case .appleLogin, .requestAccessToken, .sejongLogin:
             return .post
+        case .setNickname:
+            return .put
         }
     }
     
@@ -57,12 +62,14 @@ extension RankInAPI: Router, URLRequestConvertible {
             return refreshToken.asDictionary()
         case .sejongLogin(let sejongLoginInfoDTO):
             return sejongLoginInfoDTO.asDictionary()
+        case .setNickname(_, let nickname):
+            return nickname.asDictionary()
         }
     }
     
     var encoding: ParameterEncoding? {
         switch self {
-        case .appleLogin, .requestAccessToken, .sejongLogin:
+        case .appleLogin, .requestAccessToken, .sejongLogin, .setNickname:
             return JSONEncoding.default
         }
     }

--- a/RankIn/RankIn/Data/Network/RankInAPI.swift
+++ b/RankIn/RankIn/Data/Network/RankInAPI.swift
@@ -11,6 +11,7 @@ import Alamofire
 enum RankInAPI {
     
     case appleLogin(appleLoginDTO: AppleLoginDTO)
+    case requestAccessToken(refreshToken: String)
     
 }
 
@@ -22,14 +23,16 @@ extension RankInAPI: Router, URLRequestConvertible {
     
     var path: String {
         switch self {
-        case .appleLogin(let appleLoginDTO):
+        case .appleLogin:
             return "auth/apple"
+        case .requestAccessToken:
+            return "auth/refresh"
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .appleLogin(let appleLoginDTO):
+        case .appleLogin, .requestAccessToken:
             return .post
         }
     }
@@ -47,12 +50,14 @@ extension RankInAPI: Router, URLRequestConvertible {
         switch self {
         case .appleLogin(let appleLoginDTO):
             return appleLoginDTO.asDictionary()
+        case .requestAccessToken(let refreshToken):
+            return refreshToken.asDictionary()
         }
     }
     
     var encoding: ParameterEncoding? {
         switch self {
-        case .appleLogin:
+        case .appleLogin, .requestAccessToken:
             return JSONEncoding.default
         }
     }

--- a/RankIn/RankIn/Data/Network/RankInAPI.swift
+++ b/RankIn/RankIn/Data/Network/RankInAPI.swift
@@ -12,6 +12,7 @@ enum RankInAPI {
     
     case appleLogin(appleLoginDTO: AppleLoginDTO)
     case requestAccessToken(refreshToken: String)
+    case sejongLogin(SejongLoginInfoDTO: SejongLoginInfoDTO)
     
 }
 
@@ -27,12 +28,14 @@ extension RankInAPI: Router, URLRequestConvertible {
             return "auth/apple"
         case .requestAccessToken:
             return "auth/refresh"
+        case .sejongLogin:
+            return "auth/sejong"
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        case .appleLogin, .requestAccessToken:
+        case .appleLogin, .requestAccessToken, .sejongLogin:
             return .post
         }
     }
@@ -52,12 +55,14 @@ extension RankInAPI: Router, URLRequestConvertible {
             return appleLoginDTO.asDictionary()
         case .requestAccessToken(let refreshToken):
             return refreshToken.asDictionary()
+        case .sejongLogin(let sejongLoginInfoDTO):
+            return sejongLoginInfoDTO.asDictionary()
         }
     }
     
     var encoding: ParameterEncoding? {
         switch self {
-        case .appleLogin, .requestAccessToken:
+        case .appleLogin, .requestAccessToken, .sejongLogin:
             return JSONEncoding.default
         }
     }

--- a/RankIn/RankIn/Data/Repository/DefaultLoginRepository.swift
+++ b/RankIn/RankIn/Data/Repository/DefaultLoginRepository.swift
@@ -28,8 +28,9 @@ final class DefaultLoginRepository: LoginRepository {
             ).responseDecodable(of: LoginResultDTO.self) { response in
                 switch response.result {
                 case .success(let data):
-                    KeyChainManager.create(token: .access, content: data.accessToken)
-                    KeyChainManager.create(token: .refresh, content: data.refreshToken)
+                    KeyChainManager.create(storeElement: .accessToken, content: data.accessToken)
+                    KeyChainManager.create(storeElement: .refreshToken, content: data.refreshToken)
+                    KeyChainManager.create(storeElement: .userID, content: String(data.userID))
                     
                     observer.onNext(data.isMember)
                 case .failure(let error):

--- a/RankIn/RankIn/Data/Repository/DefaultLoginRepository.swift
+++ b/RankIn/RankIn/Data/Repository/DefaultLoginRepository.swift
@@ -16,23 +16,22 @@ final class DefaultLoginRepository: LoginRepository {
         self.session = session
     }
     
-    func appleLogin(appleLoginModel: AppleLoginModel) -> Observable<JWT> {
-        return Observable<JWT>.create { observer -> Disposable in
+    func appleLogin(appleLoginModel: AppleLoginModel) -> Observable<Bool> {
+        return Observable<Bool>.create { observer -> Disposable in
             self.session.request(
                 RankInAPI.appleLogin(
                     appleLoginDTO: AppleLoginDTO(
                         identityToken: appleLoginModel.identityToken,
                         authorizationCode: appleLoginModel.authorizationCode
                     )
-                ),
-                interceptor: AuthManager()
-            ).responseDecodable(of: JWTDTO.self) { response in
+                )
+            ).responseDecodable(of: LoginResultDTO.self) { response in
                 switch response.result {
                 case .success(let data):
                     KeyChainManager.create(token: .access, content: data.accessToken)
                     KeyChainManager.create(token: .refresh, content: data.refreshToken)
                     
-                    observer.onNext(JWT(accessToken: data.accessToken, refreshToken: data.refreshToken))
+                    observer.onNext(data.isMember)
                 case .failure(let error):
                     dump(error)
                     observer.onError(error)

--- a/RankIn/RankIn/Data/Repository/DefaultLoginRepository.swift
+++ b/RankIn/RankIn/Data/Repository/DefaultLoginRepository.swift
@@ -24,7 +24,8 @@ final class DefaultLoginRepository: LoginRepository {
                         identityToken: appleLoginModel.identityToken,
                         authorizationCode: appleLoginModel.authorizationCode
                     )
-                )
+                ),
+                interceptor: AuthManager()
             ).responseDecodable(of: JWTDTO.self) { response in
                 switch response.result {
                 case .success(let data):

--- a/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
+++ b/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
@@ -60,7 +60,31 @@ final class DefaultSignUpRepository: SignUpRepository {
             }
             
             return Disposables.create()
+        }
+    }
+    
+    func setGrade(grade: String) -> Observable<Void> {
+        return Observable<Void>.create { observer -> Disposable in
+            if let userID = KeyChainManager.read(storeElement: .userID) {
+                self.session.request(
+                    RankInAPI.setGrade(
+                        userID: userID, grade: grade
+                    ),
+                    interceptor: AuthManager()
+                )
+                .responseData(completionHandler: { response in
+                    switch response.result {
+                    case .success:
+                        observer.onNext(())
+                    case .failure(let error):
+                        observer.onError(error)
+                    }
+                })
+            } else {
+                observer.onError(RepositoryError.noUserID)
+            }
             
+            return Disposables.create()
         }
     }
     

--- a/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
+++ b/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
@@ -1,0 +1,37 @@
+//
+//  DefaultSignUpRepository.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import Alamofire
+import RxSwift
+
+final class DefaultSignUpRepository: SignUpRepository {
+    
+    let session: Session
+    
+    init(session: Session) {
+        self.session = session
+    }
+    
+    func sejongLogin(loginInfo: SejongLoginInfo) -> Observable<Bool> {
+        return Observable<Bool>.create { observer -> Disposable in
+            self.session.request(RankInAPI.sejongLogin(SejongLoginInfoDTO: SejongLoginInfoDTO(
+                id: loginInfo.id, pw: loginInfo.password
+            )), interceptor: AuthManager())
+            .responseDecodable(of: SejongLoginResultDTO.self) { response in
+                switch response.result {
+                case .success(let data):
+                    observer.onNext(data.isSejong)
+                case .failure(let error):
+                    observer.onError(error)
+                }
+            }
+            
+            return Disposables.create()
+        }
+    }
+    
+}

--- a/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
+++ b/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
@@ -19,7 +19,7 @@ final class DefaultSignUpRepository: SignUpRepository {
     func sejongLogin(loginInfo: SejongLoginInfo) -> Observable<Bool> {
         return Observable<Bool>.create { observer -> Disposable in
             self.session.request(RankInAPI.sejongLogin(SejongLoginInfoDTO: SejongLoginInfoDTO(
-                id: loginInfo.id, pw: loginInfo.password
+                id: loginInfo.id, pw: loginInfo.pw
             )), interceptor: AuthManager())
             .responseDecodable(of: SejongLoginResultDTO.self) { response in
                 switch response.result {

--- a/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
+++ b/RankIn/RankIn/Data/Repository/DefaultSignUpRepository.swift
@@ -24,13 +24,43 @@ final class DefaultSignUpRepository: SignUpRepository {
             .responseDecodable(of: SejongLoginResultDTO.self) { response in
                 switch response.result {
                 case .success(let data):
-                    observer.onNext(data.isSejong)
+                    observer.onNext(data.isAuthorized)
                 case .failure(let error):
                     observer.onError(error)
                 }
             }
             
             return Disposables.create()
+        }
+    }
+    
+    func setNickname(nickname: String) -> Observable<Bool> {
+        return Observable<Bool>.create { observer -> Disposable in
+            if let userID = KeyChainManager.read(storeElement: .userID) {
+                self.session.request(
+                    RankInAPI.setNickname(
+                        userID: userID, nickname: nickname
+                    ),
+                    interceptor: AuthManager()
+                )
+                .responseData(completionHandler: { response in
+                    switch response.result {
+                    case .success:
+                        observer.onNext(true)
+                    case .failure(let error):
+                        if error.responseCode == 409 {
+                            observer.onNext(false)
+                        } else {
+                            observer.onError(error)
+                        }
+                    }
+                })
+            } else {  
+                observer.onError(RepositoryError.noUserID)
+            }
+            
+            return Disposables.create()
+            
         }
     }
     

--- a/RankIn/RankIn/Data/Utils/KeyChainManager.swift
+++ b/RankIn/RankIn/Data/Utils/KeyChainManager.swift
@@ -9,19 +9,20 @@ import Foundation
 
 final class KeyChainManager {
     
-    enum Token: String {
+    enum StoreElement: String {
         
-        case access
-        case refresh
+        case accessToken
+        case refreshToken
+        case userID
         
     }
     
     static let serviceName = "RankIn"
     
-    static func create(token: Token, content: String) {
+    static func create(storeElement: StoreElement, content: String) {
         let query: NSDictionary = [
             kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: token.rawValue,
+            kSecAttrAccount: storeElement.rawValue,
             kSecValueData: content.data(using: .utf8, allowLossyConversion: false) as Any
         ]
         SecItemDelete(query)
@@ -30,10 +31,10 @@ final class KeyChainManager {
         assert(status == noErr, "failed to save Token")
     }
     
-    static func read(token: Token) -> String? {
+    static func read(storeElement: StoreElement) -> String? {
         let query: NSDictionary = [
             kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: token.rawValue,
+            kSecAttrAccount: storeElement.rawValue,
             kSecReturnData: kCFBooleanTrue as Any,
             kSecMatchLimit: kSecMatchLimitOne
         ]
@@ -50,10 +51,10 @@ final class KeyChainManager {
         }
     }
     
-    static func delete(token: Token) {
+    static func delete(storeElement: StoreElement) {
         let query: NSDictionary = [
             kSecClass: kSecClassGenericPassword,
-            kSecAttrAccount: token.rawValue
+            kSecAttrAccount: storeElement.rawValue
         ]
         let status = SecItemDelete(query)
         assert(status == noErr, "failed to delete the value, status code = \(status)")

--- a/RankIn/RankIn/Domain/Interface/AppleLoginUseCase.swift
+++ b/RankIn/RankIn/Domain/Interface/AppleLoginUseCase.swift
@@ -13,6 +13,6 @@ protocol AppleLoginUseCase {
     
     func execute(
         requiredValue: AppleLoginModel
-    ) -> Observable<JWT>
+    ) -> Observable<Bool>
     
 }

--- a/RankIn/RankIn/Domain/Interface/Repository/LoginRepository.swift
+++ b/RankIn/RankIn/Domain/Interface/Repository/LoginRepository.swift
@@ -14,6 +14,6 @@ protocol LoginRepository {
     
     func appleLogin(
         appleLoginModel: AppleLoginModel
-    ) -> Observable<JWT>
+    ) -> Observable<Bool>
     
 }

--- a/RankIn/RankIn/Domain/Interface/Repository/SignUpRepository.swift
+++ b/RankIn/RankIn/Domain/Interface/Repository/SignUpRepository.swift
@@ -1,0 +1,14 @@
+//
+//  SignUpRepository.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import RxSwift
+
+protocol SignUpRepository {
+    
+    func sejongLogin(loginInfo: SejongLoginInfo) -> Observable<Bool>
+    
+}

--- a/RankIn/RankIn/Domain/Interface/Repository/SignUpRepository.swift
+++ b/RankIn/RankIn/Domain/Interface/Repository/SignUpRepository.swift
@@ -11,5 +11,6 @@ protocol SignUpRepository {
     
     func sejongLogin(loginInfo: SejongLoginInfo) -> Observable<Bool>
     func setNickname(nickname: String) -> Observable<Bool>
+    func setGrade(grade: String) -> Observable<Void>
     
 }

--- a/RankIn/RankIn/Domain/Interface/Repository/SignUpRepository.swift
+++ b/RankIn/RankIn/Domain/Interface/Repository/SignUpRepository.swift
@@ -10,5 +10,6 @@ import RxSwift
 protocol SignUpRepository {
     
     func sejongLogin(loginInfo: SejongLoginInfo) -> Observable<Bool>
+    func setNickname(nickname: String) -> Observable<Bool>
     
 }

--- a/RankIn/RankIn/Domain/Interface/SetGradeUseCase.swift
+++ b/RankIn/RankIn/Domain/Interface/SetGradeUseCase.swift
@@ -1,0 +1,16 @@
+//
+//  SetGradeUseCase.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/17/24.
+//
+
+import RxSwift
+
+protocol SetGradeUseCase {
+    
+    var repository: SignUpRepository { get }
+    
+    func execute(grade: String) -> Observable<Void>
+    
+}

--- a/RankIn/RankIn/Domain/Interface/SetNicknameUseCase.swift
+++ b/RankIn/RankIn/Domain/Interface/SetNicknameUseCase.swift
@@ -1,0 +1,16 @@
+//
+//  SetNicknameUseCase.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/14/24.
+//
+
+import RxSwift
+
+protocol SetNicknameUseCase {
+    
+    var repository: SignUpRepository { get }
+    
+    func execute(nickname: String) -> Observable<Bool>
+    
+}

--- a/RankIn/RankIn/Domain/Model/SejongLoginInfo.swift
+++ b/RankIn/RankIn/Domain/Model/SejongLoginInfo.swift
@@ -1,0 +1,15 @@
+//
+//  SejongLoginInfo.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import Foundation
+
+struct SejongLoginInfo {
+    
+    let id: String
+    let pw: String
+    
+}

--- a/RankIn/RankIn/Domain/UseCase/DefaultAppleLoginUseCase.swift
+++ b/RankIn/RankIn/Domain/UseCase/DefaultAppleLoginUseCase.swift
@@ -13,7 +13,7 @@ struct DefaultAppleLoginUseCase: AppleLoginUseCase {
     
     func execute(
         requiredValue: AppleLoginModel
-    ) -> Observable<JWT> {
+    ) -> Observable<Bool> {
         return repository.appleLogin(appleLoginModel: requiredValue)
     }
 }

--- a/RankIn/RankIn/Domain/UseCase/DefaultSejongLoginUseCase.swift
+++ b/RankIn/RankIn/Domain/UseCase/DefaultSejongLoginUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  DefaultSejongLoginUseCase.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import RxSwift
+
+struct DefaultSejongLoginUseCase: SejongLoginUseCase {
+    
+    let repository: SignUpRepository
+    
+    func execute(loginInfo: SejongLoginInfo) -> Observable<Bool> {
+        return repository.sejongLogin(loginInfo: loginInfo)
+    }
+    
+}

--- a/RankIn/RankIn/Domain/UseCase/DefaultSetGradeUseCase.swift
+++ b/RankIn/RankIn/Domain/UseCase/DefaultSetGradeUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  DefaultSetGradeUseCase.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/17/24.
+//
+
+import RxSwift
+
+struct DefaultSetGradeUseCase: SetGradeUseCase {
+    
+    let repository: SignUpRepository
+    
+    func execute(grade: String) -> Observable<Void> {
+        return repository.setGrade(grade: grade)
+    }
+    
+}

--- a/RankIn/RankIn/Domain/UseCase/DefaultSetNicknameUseCase.swift
+++ b/RankIn/RankIn/Domain/UseCase/DefaultSetNicknameUseCase.swift
@@ -1,0 +1,18 @@
+//
+//  DefaultSetNicknameUseCase.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/14/24.
+//
+
+import RxSwift
+
+struct DefaultSetNicknameUseCase: SetNicknameUseCase {
+    
+    let repository: SignUpRepository
+    
+    func execute(nickname: String) -> Observable<Bool> {
+        return repository.setNickname(nickname: nickname)
+    }
+    
+}

--- a/RankIn/RankIn/Presentation/Home/HomeViewController.swift
+++ b/RankIn/RankIn/Presentation/Home/HomeViewController.swift
@@ -9,8 +9,6 @@ import UIKit
 
 final class HomeViewController: UIViewController {
     
-//    private
-    
     init() {
         super.init(nibName: nil, bundle: nil)
         

--- a/RankIn/RankIn/Presentation/Login/View/LoginViewController.swift
+++ b/RankIn/RankIn/Presentation/Login/View/LoginViewController.swift
@@ -96,9 +96,13 @@ private extension LoginViewController {
         let output = viewModel.transform(input: input)
         
         output.loginSuccessOutput
-            .bind { [weak self] in
+            .bind { [weak self] isMember in
                 guard let self = self else { return }
-                self.present(mainTabBarController, animated: true)
+                if isMember {
+                    self.present(mainTabBarController, animated: true)
+                } else {
+                    // TODO: 회원가입으로 이동
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/RankIn/RankIn/Presentation/Login/View/LoginViewController.swift
+++ b/RankIn/RankIn/Presentation/Login/View/LoginViewController.swift
@@ -38,14 +38,14 @@ final class LoginViewController: UIViewController {
     }()
     
     private let viewModel: LoginViewModel
-    private let homeViewController: HomeViewController
+    private let mainTabBarController: UITabBarController
     
     init(
         viewModel: LoginViewModel,
-        homeViewController: HomeViewController
+        mainTabBarController: UITabBarController
     ) {
         self.viewModel = viewModel
-        self.homeViewController = homeViewController
+        self.mainTabBarController = mainTabBarController
         
         super.init(nibName: nil, bundle: nil)
         self.modalPresentationStyle = .fullScreen
@@ -98,7 +98,7 @@ private extension LoginViewController {
         output.loginSuccessOutput
             .bind { [weak self] in
                 guard let self = self else { return }
-                self.present(homeViewController, animated: true)
+                self.present(mainTabBarController, animated: true)
             }
             .disposed(by: disposeBag)
     }
@@ -131,7 +131,6 @@ extension LoginViewController: ASAuthorizationControllerDelegate {
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
-        print("aaaaa")
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             let userIdentifier = appleIDCredential.user

--- a/RankIn/RankIn/Presentation/Login/View/LoginViewController.swift
+++ b/RankIn/RankIn/Presentation/Login/View/LoginViewController.swift
@@ -39,13 +39,16 @@ final class LoginViewController: UIViewController {
     
     private let viewModel: LoginViewModel
     private let mainTabBarController: UITabBarController
+    private let signUpNavigationController: UINavigationController
     
     init(
         viewModel: LoginViewModel,
-        mainTabBarController: UITabBarController
+        mainTabBarController: UITabBarController,
+        signUpNavigationController: UINavigationController
     ) {
         self.viewModel = viewModel
         self.mainTabBarController = mainTabBarController
+        self.signUpNavigationController = signUpNavigationController
         
         super.init(nibName: nil, bundle: nil)
         self.modalPresentationStyle = .fullScreen
@@ -101,7 +104,7 @@ private extension LoginViewController {
                 if isMember {
                     self.present(mainTabBarController, animated: true)
                 } else {
-                    // TODO: 회원가입으로 이동
+                    self.present(signUpNavigationController, animated: true)
                 }
             }
             .disposed(by: disposeBag)

--- a/RankIn/RankIn/Presentation/Login/ViewModel/DefaultLoginViewModel.swift
+++ b/RankIn/RankIn/Presentation/Login/ViewModel/DefaultLoginViewModel.swift
@@ -50,7 +50,6 @@ private extension DefaultLoginViewModel {
             } onError: { [weak self] error in
                 dump(error)
                 // TODO: 실패 핸들링
-                self?.loginSuccessOutput.accept(())
             }
             .disposed(by: disposeBag)
     }

--- a/RankIn/RankIn/Presentation/Login/ViewModel/DefaultLoginViewModel.swift
+++ b/RankIn/RankIn/Presentation/Login/ViewModel/DefaultLoginViewModel.swift
@@ -15,7 +15,7 @@ final class DefaultLoginViewModel: LoginViewModel {
     let dependency: LoginViewModelDependency
     
     // MARK: Output
-    let loginSuccessOutput = PublishRelay<Void>()
+    let loginSuccessOutput = PublishRelay<Bool>()
     
     init(dependency: LoginViewModelDependency) {
         self.dependency = dependency
@@ -45,8 +45,8 @@ private extension DefaultLoginViewModel {
             .execute(
                 requiredValue: appleLoginModel
             )
-            .subscribe { [weak self] jwt in
-                self?.loginSuccessOutput.accept(())
+            .subscribe { [weak self] isMember in
+                self?.loginSuccessOutput.accept(isMember)
             } onError: { [weak self] error in
                 dump(error)
                 // TODO: 실패 핸들링

--- a/RankIn/RankIn/Presentation/Login/ViewModel/Protocol/LoginViewModel.swift
+++ b/RankIn/RankIn/Presentation/Login/ViewModel/Protocol/LoginViewModel.swift
@@ -24,7 +24,7 @@ struct LoginViewModelInput {
 
 struct LoginViewModelOutput {
     
-    let loginSuccessOutput: PublishRelay<Void>
+    let loginSuccessOutput: PublishRelay<Bool>
     
 }
 

--- a/RankIn/RankIn/Presentation/MyPage/View/MyPageViewController.swift
+++ b/RankIn/RankIn/Presentation/MyPage/View/MyPageViewController.swift
@@ -1,21 +1,17 @@
 //
-//  HomeViewController.swift
+//  MyPageViewController.swift
 //  RankIn
 //
-//  Created by 조성민 on 3/21/24.
+//  Created by 조성민 on 4/6/24.
 //
 
 import UIKit
 
-final class HomeViewController: UIViewController {
-    
-//    private
-    
+final class MyPageViewController: UIViewController {
+
     init() {
         super.init(nibName: nil, bundle: nil)
         
-        self.modalPresentationStyle = .fullScreen
-        self.modalTransitionStyle = .crossDissolve
     }
     
     required init?(coder: NSCoder) {
@@ -25,6 +21,7 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.view.backgroundColor = .sejongPrimary
     }
 
 }

--- a/RankIn/RankIn/Presentation/SignUp/View/GradeViewController.swift
+++ b/RankIn/RankIn/Presentation/SignUp/View/GradeViewController.swift
@@ -1,22 +1,22 @@
 //
-//  NicknameViewController.swift
+//  GradeViewController.swift
 //  RankIn
 //
-//  Created by 조성민 on 4/13/24.
+//  Created by 조성민 on 4/17/24.
 //
 
 import UIKit
 import RxSwift
 import RxRelay
 
-final class NicknameViewController: UIViewController {
+final class GradeViewController: UIViewController {
     
     private let disposeBag = DisposeBag()
     
     // MARK: Input
     private let nextButtonTapped = PublishRelay<String>()
     
-    private let nickname: UITextField = {
+    private let grade: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: textField.bounds.height))
@@ -27,7 +27,7 @@ final class NicknameViewController: UIViewController {
         textField.backgroundColor = .white
         textField.textColor = .black
         textField.attributedPlaceholder = NSAttributedString(
-            string: "닉네임",
+            string: "학점",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray]
         )
         
@@ -49,12 +49,12 @@ final class NicknameViewController: UIViewController {
         return button
     }()
     
-    private let viewModel: NicknameViewModel
+    private let viewModel: GradeViewModel
     
     init(
-        nicknameViewModel: NicknameViewModel
+        gradeViewModel: GradeViewModel
     ) {
-        self.viewModel = nicknameViewModel
+        self.viewModel = gradeViewModel
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -73,7 +73,7 @@ final class NicknameViewController: UIViewController {
     
 }
 
-private extension NicknameViewController {
+private extension GradeViewController {
     
     func setUI() {
         view.backgroundColor = .systemGray6
@@ -83,30 +83,30 @@ private extension NicknameViewController {
     }
     
     func setHierarchy() {
-        view.addSubview(nickname)
+        view.addSubview(grade)
         view.addSubview(nextButton)
     }
     
     func setConstraints() {
         NSLayoutConstraint.activate([
-            nickname.widthAnchor.constraint(equalToConstant: 285),
-            nickname.heightAnchor.constraint(equalToConstant: 44),
-            nickname.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
-            nickname.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 258)
+            grade.widthAnchor.constraint(equalToConstant: 285),
+            grade.heightAnchor.constraint(equalToConstant: 44),
+            grade.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            grade.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 258)
         ])
         
         NSLayoutConstraint.activate([
-            nextButton.trailingAnchor.constraint(equalTo: nickname.trailingAnchor),
-            nextButton.topAnchor.constraint(equalTo: nickname.bottomAnchor, constant: 17.5)
+            nextButton.trailingAnchor.constraint(equalTo: grade.trailingAnchor),
+            nextButton.topAnchor.constraint(equalTo: grade.bottomAnchor, constant: 17.5)
         ])
     }
     
     func bind() {
-        let input = NicknameViewModelInput(nextButtonTapped: nextButtonTapped)
+        let input = GradeViewModelInput(nextButtonTapped: nextButtonTapped)
         
         let output = viewModel.transform(input: input)
         
-        output.nicknameSuccess
+        output.gradeSuccess
             .subscribe { _ in
                 // TODO: 다음 VC 띄우기
             } onError: { error in
@@ -114,9 +114,9 @@ private extension NicknameViewController {
             }
             .disposed(by: disposeBag)
         
-        output.nicknameFailure
+        output.gradeFailure
             .subscribe { _ in
-                self.presentToast(toastCase: .duplicatedNickname)
+                self.presentToast(toastCase: .invalidGradeInput)
             } onError: { error in
                 dump(error)
             }
@@ -128,11 +128,11 @@ private extension NicknameViewController {
         nextButton.rx
             .tap
             .bind(onNext: { _ in
-                guard let nicknameText = self.nickname.text else {
-                    self.presentToast(toastCase: .noNicknameInput)
+                guard let gradeText = self.grade.text else {
+                    self.presentToast(toastCase: .noGradeInput)
                     return
                 }
-                self.nextButtonTapped.accept(nicknameText)
+                self.nextButtonTapped.accept(gradeText)
             })
             .disposed(by: disposeBag)
     }

--- a/RankIn/RankIn/Presentation/SignUp/View/NicknameViewController.swift
+++ b/RankIn/RankIn/Presentation/SignUp/View/NicknameViewController.swift
@@ -1,0 +1,123 @@
+//
+//  NicknameViewController.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import UIKit
+import RxSwift
+import RxRelay
+
+final class NicknameViewController: UIViewController {
+
+    private let disposeBag = DisposeBag()
+    
+    // MARK: Input
+    private let nextButtonTapped = PublishRelay<String>()
+    
+    private let nickname: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: textField.bounds.height))
+        textField.leftViewMode = .always
+        textField.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: textField.bounds.height))
+        textField.rightViewMode = .always
+        textField.layer.cornerRadius = 6
+        textField.backgroundColor = .white
+        textField.textColor = .black
+        textField.attributedPlaceholder = NSAttributedString(
+            string: "닉네임",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray]
+        )
+
+        return textField
+    }()
+    
+    private let nextButton: UIButton = {
+        var attributeTitle = AttributedString("다음")
+        attributeTitle.font = UIFont.pretendard(type: .semiBold, size: 17)
+        
+        var configuration = UIButton.Configuration.filled()
+        configuration.attributedTitle = attributeTitle
+        configuration.baseBackgroundColor = .systemGray
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.configuration = configuration
+        
+        return button
+    }()
+    
+    private let viewModel: NicknameViewModel
+    
+    init(
+        nicknameViewModel: NicknameViewModel
+    ) {
+        self.viewModel = nicknameViewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setUI()
+        bind()
+        react()
+    }
+
+}
+
+private extension NicknameViewController {
+    
+    func setUI() {
+        view.backgroundColor = .systemGray6
+        
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setHierarchy() {
+        view.addSubview(nickname)
+        view.addSubview(nextButton)
+    }
+    
+    func setConstraints() {
+        NSLayoutConstraint.activate([
+            nickname.widthAnchor.constraint(equalToConstant: 285),
+            nickname.heightAnchor.constraint(equalToConstant: 44),
+            nickname.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            nickname.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 258)
+        ])
+        
+        NSLayoutConstraint.activate([
+            nextButton.trailingAnchor.constraint(equalTo: nickname.trailingAnchor),
+            nextButton.topAnchor.constraint(equalTo: nickname.bottomAnchor, constant: 17.5)
+        ])
+    }
+    
+    func bind() {
+//        let input = SejongLoginViewModelInput(
+//            loginButtonTapped: loginButtonTapped
+//        )
+//        
+//        let output = viewModel.transform(input: input)
+    }
+    
+    func react() {
+        nextButton.rx
+            .tap
+            .bind(onNext: { _ in
+                self.nextButtonTapped.accept(
+                    self.nickname.text ?? ""
+                )
+            })
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/RankIn/RankIn/Presentation/SignUp/View/NicknameViewController.swift
+++ b/RankIn/RankIn/Presentation/SignUp/View/NicknameViewController.swift
@@ -50,11 +50,14 @@ final class NicknameViewController: UIViewController {
     }()
     
     private let viewModel: NicknameViewModel
+    private let gradeViewController: GradeViewController
     
     init(
-        nicknameViewModel: NicknameViewModel
+        nicknameViewModel: NicknameViewModel,
+        gradeViewController: GradeViewController
     ) {
         self.viewModel = nicknameViewModel
+        self.gradeViewController = gradeViewController
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -108,7 +111,7 @@ private extension NicknameViewController {
         
         output.nicknameSuccess
             .subscribe { _ in
-                // TODO: 다음 VC 띄우기
+                self.navigationController?.pushViewController(self.gradeViewController, animated: true)
             } onError: { error in
                 dump(error)
             }

--- a/RankIn/RankIn/Presentation/SignUp/View/NicknameViewController.swift
+++ b/RankIn/RankIn/Presentation/SignUp/View/NicknameViewController.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxRelay
 
 final class NicknameViewController: UIViewController {
-
+    
     private let disposeBag = DisposeBag()
     
     // MARK: Input
@@ -30,7 +30,7 @@ final class NicknameViewController: UIViewController {
             string: "닉네임",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray]
         )
-
+        
         return textField
     }()
     
@@ -65,12 +65,12 @@ final class NicknameViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         setUI()
         bind()
         react()
     }
-
+    
 }
 
 private extension NicknameViewController {
@@ -102,20 +102,37 @@ private extension NicknameViewController {
     }
     
     func bind() {
-//        let input = SejongLoginViewModelInput(
-//            loginButtonTapped: loginButtonTapped
-//        )
-//        
-//        let output = viewModel.transform(input: input)
+        let input = NicknameViewModelInput(nextButtonTapped: nextButtonTapped)
+        
+        let output = viewModel.transform(input: input)
+        
+        output.nicknameSuccess
+            .subscribe { _ in
+                // TODO: 다음 VC 띄우기
+            } onError: { error in
+                dump(error)
+            }
+            .disposed(by: disposeBag)
+        
+        output.nicknameFailure
+            .subscribe { _ in
+                self.presentToast(toastCase: .duplicatedNickname)
+            } onError: { error in
+                dump(error)
+            }
+            .disposed(by: disposeBag)
+        
     }
     
     func react() {
         nextButton.rx
             .tap
             .bind(onNext: { _ in
-                self.nextButtonTapped.accept(
-                    self.nickname.text ?? ""
-                )
+                guard let nicknameText = self.nickname.text else {
+                    self.presentToast(toastCase: .noInput)
+                    return
+                }
+                self.nextButtonTapped.accept(nicknameText)
             })
             .disposed(by: disposeBag)
     }

--- a/RankIn/RankIn/Presentation/SignUp/View/SejongLoginViewController.swift
+++ b/RankIn/RankIn/Presentation/SignUp/View/SejongLoginViewController.swift
@@ -1,0 +1,151 @@
+//
+//  SejongLoginViewController.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import UIKit
+import RxSwift
+import RxRelay
+
+final class SejongLoginViewController: UIViewController {
+
+    private let disposeBag = DisposeBag()
+    
+    // MARK: Input
+    private let loginButtonTapped = PublishRelay<SejongLoginInfo>()
+    
+    private let id: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: textField.bounds.height))
+        textField.leftViewMode = .always
+        textField.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: textField.bounds.height))
+        textField.rightViewMode = .always
+        textField.layer.cornerRadius = 6
+        textField.backgroundColor = .white
+        textField.textColor = .black
+        textField.attributedPlaceholder = NSAttributedString(
+            string: "학번",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray]
+        )
+
+        return textField
+    }()
+    
+    private let password: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 25, height: textField.bounds.height))
+        textField.leftViewMode = .always
+        textField.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: textField.bounds.height))
+        textField.leftViewMode = .always
+        textField.layer.cornerRadius = 6
+        textField.backgroundColor = .white
+        textField.textColor = .black
+        textField.attributedPlaceholder = NSAttributedString(
+            string: "비밀번호",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.systemGray]
+        )
+        textField.isSecureTextEntry = true
+        
+        return textField
+    }()
+    
+    private let loginButton: UIButton = {
+        var attributeTitle = AttributedString("로그인")
+        attributeTitle.font = UIFont.pretendard(type: .semiBold, size: 17)
+        
+        var configuration = UIButton.Configuration.filled()
+        configuration.attributedTitle = attributeTitle
+        configuration.baseBackgroundColor = .systemGray
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.configuration = configuration
+        
+        return button
+    }()
+    
+    private let viewModel: SejongLoginViewModel
+    
+    init(sejongLoginViewModel: SejongLoginViewModel) {
+        self.viewModel = sejongLoginViewModel
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setUI()
+        bind()
+        react()
+    }
+
+}
+
+private extension SejongLoginViewController {
+    
+    func setUI() {
+        view.backgroundColor = .systemGray6
+        
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setHierarchy() {
+        view.addSubview(id)
+        view.addSubview(password)
+        view.addSubview(loginButton)
+    }
+    
+    func setConstraints() {
+        NSLayoutConstraint.activate([
+            id.widthAnchor.constraint(equalToConstant: 285),
+            id.heightAnchor.constraint(equalToConstant: 44),
+            id.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            id.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 288)
+        ])
+        
+        NSLayoutConstraint.activate([
+            password.widthAnchor.constraint(equalToConstant: 285),
+            password.heightAnchor.constraint(equalToConstant: 44),
+            password.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
+            password.topAnchor.constraint(equalTo: id.bottomAnchor, constant: 30)
+        ])
+        
+        NSLayoutConstraint.activate([
+            loginButton.trailingAnchor.constraint(equalTo: password.trailingAnchor),
+            loginButton.topAnchor.constraint(equalTo: password.bottomAnchor, constant: 27.5)
+        ])
+    }
+    
+    func bind() {
+        let input = SejongLoginViewModelInput(
+            loginButtonTapped: loginButtonTapped
+        )
+        
+        let output = viewModel.transform(input: input)
+    }
+    
+    func react() {
+        loginButton.rx
+            .tap
+            .bind(onNext: { _ in
+                self.loginButtonTapped.accept(
+                    SejongLoginInfo(
+                        id: self.id.text ?? "",
+                        pw: self.password.text ?? ""
+                    )
+                )
+            })
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/RankIn/RankIn/Presentation/SignUp/View/SejongLoginViewController.swift
+++ b/RankIn/RankIn/Presentation/SignUp/View/SejongLoginViewController.swift
@@ -69,9 +69,14 @@ final class SejongLoginViewController: UIViewController {
     }()
     
     private let viewModel: SejongLoginViewModel
+    private let nicknameViewController: NicknameViewController
     
-    init(sejongLoginViewModel: SejongLoginViewModel) {
+    init(
+        sejongLoginViewModel: SejongLoginViewModel,
+        nicknameViewController: NicknameViewController
+    ) {
         self.viewModel = sejongLoginViewModel
+        self.nicknameViewController = nicknameViewController
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -110,7 +115,7 @@ private extension SejongLoginViewController {
             id.widthAnchor.constraint(equalToConstant: 285),
             id.heightAnchor.constraint(equalToConstant: 44),
             id.centerXAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor),
-            id.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 288)
+            id.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 258)
         ])
         
         NSLayoutConstraint.activate([
@@ -132,6 +137,21 @@ private extension SejongLoginViewController {
         )
         
         let output = viewModel.transform(input: input)
+        
+        output.loginFailed
+            .bind { _ in
+                // TODO: login 실패 처리
+                print("loginFailed")
+            }
+            .disposed(by: disposeBag)
+        
+        output.loginSuccessed
+            .bind { _ in
+                // TODO: login 성공 처리
+                self.navigationController?.pushViewController(self.nicknameViewController, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
     }
     
     func react() {

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultGradeViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultGradeViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  DefaultGradeViewModel.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/17/24.
+//
+
+import RxSwift
+import RxRelay
+
+final class DefaultGradeViewModel: GradeViewModel {
+    
+    private let disposeBag = DisposeBag()
+    
+    private let gradeSuccess = PublishRelay<Void>()
+    private let gradeFailure = PublishRelay<Void>()
+    
+    let dependency: GradeViewModelDependency
+    
+    func transform(input: GradeViewModelInput) -> GradeViewModelOutput {
+        input.nextButtonTapped
+            .bind { grade in
+                self.setGrade(grade: grade)
+            }
+            .disposed(by: disposeBag)
+        
+        return GradeViewModelOutput(
+            gradeSuccess: gradeSuccess,
+            gradeFailure: gradeFailure
+        )
+    }
+    
+    init(dependency: GradeViewModelDependency) {
+        self.dependency = dependency
+    }
+    
+}
+
+private extension DefaultGradeViewModel {
+    
+    func setGrade(grade: String) {
+        // TODO: grade 유효성 검사
+        if false {
+            gradeFailure.accept(())
+        }
+        dependency.setGradeUseCase
+            .execute(grade: grade)
+            .subscribe { [weak self] _ in
+                self?.gradeSuccess.accept(())
+            } onError: { error in
+                // TODO: Error 처리
+                dump(error)
+            }
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultNicknameViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultNicknameViewModel.swift
@@ -43,7 +43,6 @@ private extension DefaultNicknameViewModel {
             .execute(nickname: nickname)
             .subscribe(
                 onNext: { [weak self] isSuccess in
-                    // TODO: 닉네임 설정 성공
                     if isSuccess {
                         self?.nicknameSuccess.accept(())
                     } else {

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultNicknameViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultNicknameViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  DefaultNicknameViewModel.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/14/24.
+//
+
+import RxSwift
+
+final class DefaultNicknameViewModel: NicknameViewModel {
+    
+    private let disposeBag = DisposeBag()
+    let dependency: NicknameViewModelDependency
+    	
+    func transform(input: NicknameViewModelInput) -> NicknameViewModelOutput {
+        input.nextButtonTapped
+            .bind { nickname in
+            }
+            .disposed(by: disposeBag)
+        
+        return NicknameViewModelOutput()
+    }
+    
+    init(dependency: NicknameViewModelDependency) {
+        self.dependency = dependency
+    }
+    
+}
+
+private extension DefaultNicknameViewModel {
+    
+    func setNickname(nickname: String) {
+        dependency.setNicknameUseCase
+            .execute(nickname: nickname)
+            .subscribe(
+                onNext: { isSuccessed in
+                    // TODO: 성공 여부 처리
+                    if isSuccessed {
+                        print("닉네임 설정 성공")
+                    } else {
+                        print("닉네임 설정 실패")
+                    }
+                },
+                onError: { error in
+                    // TODO: error 처리
+                    dump(error)
+                })
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultSejongLoginViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultSejongLoginViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  DefaultSejongLoginViewModel.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import RxSwift
+import RxRelay
+
+final class DefaultSejongLoginViewModel: SejongLoginViewModel {
+    
+    private let disposeBag = DisposeBag()
+    
+    let dependency: SejongLoginViewModelDependency
+    
+    func transform(input: SejongLoginViewModelInput) -> SejongLoginViewModelOutput {
+        
+        input.loginButtonTapped
+            .bind { [weak self] loginInfo in
+                self?.sejongLogin(loginInfo: loginInfo)
+            }
+            .disposed(by: disposeBag)
+        
+        return SejongLoginViewModelOutput()
+    }
+    
+    init(dependency: SejongLoginViewModelDependency) {
+        self.dependency = dependency
+    }
+    
+}
+
+private extension DefaultSejongLoginViewModel {
+    
+    func sejongLogin(loginInfo: SejongLoginInfo) {
+        dependency
+            .sejongLoginUseCase
+            .execute(loginInfo: loginInfo)
+            .subscribe { isAuthorized in
+                // TODO: 로그인 성공 및 실패 처리
+                if isAuthorized {
+                    print("로그인 성공")
+                } else {
+                    print("로그인 실패")
+                }
+            } onError: { error in
+                dump(error)
+                // TODO: error 처리
+            }
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultSejongLoginViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/DefaultSejongLoginViewModel.swift
@@ -14,6 +14,13 @@ final class DefaultSejongLoginViewModel: SejongLoginViewModel {
     
     let dependency: SejongLoginViewModelDependency
     
+    private let loginFailed = PublishRelay<Void>()
+    private let loginSuccessed = PublishRelay<Void>()
+    
+    init(dependency: SejongLoginViewModelDependency) {
+        self.dependency = dependency
+    }
+    
     func transform(input: SejongLoginViewModelInput) -> SejongLoginViewModelOutput {
         
         input.loginButtonTapped
@@ -22,11 +29,10 @@ final class DefaultSejongLoginViewModel: SejongLoginViewModel {
             }
             .disposed(by: disposeBag)
         
-        return SejongLoginViewModelOutput()
-    }
-    
-    init(dependency: SejongLoginViewModelDependency) {
-        self.dependency = dependency
+        return SejongLoginViewModelOutput(
+            loginFailed: loginFailed,
+            loginSuccessed: loginSuccessed
+        )
     }
     
 }
@@ -40,9 +46,9 @@ private extension DefaultSejongLoginViewModel {
             .subscribe { isAuthorized in
                 // TODO: 로그인 성공 및 실패 처리
                 if isAuthorized {
-                    print("로그인 성공")
+                    self.loginSuccessed.accept(())
                 } else {
-                    print("로그인 실패")
+                    self.loginFailed.accept(())
                 }
             } onError: { error in
                 dump(error)

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/GradeViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/GradeViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  GradeViewModel.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/17/24.
+//
+
+import RxSwift
+import RxRelay
+
+protocol GradeViewModel {
+    
+    var dependency: GradeViewModelDependency { get }
+    
+    func transform(input: GradeViewModelInput) -> GradeViewModelOutput
+    
+}
+
+struct GradeViewModelInput {
+    
+    let nextButtonTapped: PublishRelay<String>
+    
+}
+
+struct GradeViewModelOutput {
+    
+    let gradeSuccess: PublishRelay<Void>
+    let gradeFailure: PublishRelay<Void>
+    
+}
+
+struct GradeViewModelDependency {
+    
+    let setGradeUseCase: SetGradeUseCase
+    
+}

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/NicknameViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/NicknameViewModel.swift
@@ -24,6 +24,9 @@ struct NicknameViewModelInput {
 
 struct NicknameViewModelOutput {
     
+    let nicknameSuccess: PublishRelay<Void>
+    let nicknameFailure: PublishRelay<Void>
+    
 }
 
 struct NicknameViewModelDependency {

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/NicknameViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/NicknameViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  NicknameViewModel.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/14/24.
+//
+
+import RxSwift
+import RxRelay
+
+protocol NicknameViewModel {
+    
+    var dependency: NicknameViewModelDependency { get }
+    
+    func transform(input: NicknameViewModelInput) -> NicknameViewModelOutput
+    
+}
+
+struct NicknameViewModelInput {
+    
+    let nextButtonTapped: PublishRelay<String>
+    
+}
+
+struct NicknameViewModelOutput {
+    
+}
+
+struct NicknameViewModelDependency {
+    
+    let setNicknameUseCase: SetNicknameUseCase
+    
+}

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/SejongLoginViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/SejongLoginViewModel.swift
@@ -24,6 +24,9 @@ struct SejongLoginViewModelInput {
 
 struct SejongLoginViewModelOutput {
     
+    let loginFailed: PublishRelay<Void>
+    let loginSuccessed: PublishRelay<Void>
+    
 }
 
 struct SejongLoginViewModelDependency {

--- a/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/SejongLoginViewModel.swift
+++ b/RankIn/RankIn/Presentation/SignUp/ViewModel/Protocol/SejongLoginViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  SejongLoginViewModel.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/13/24.
+//
+
+import RxSwift
+import RxRelay
+
+protocol SejongLoginViewModel {
+    
+    var dependency: SejongLoginViewModelDependency { get }
+    
+    func transform(input: SejongLoginViewModelInput) -> SejongLoginViewModelOutput
+    
+}
+
+struct SejongLoginViewModelInput {
+    
+    let loginButtonTapped: PublishRelay<SejongLoginInfo>
+    
+}
+
+struct SejongLoginViewModelOutput {
+    
+}
+
+struct SejongLoginViewModelDependency {
+    
+    let sejongLoginUseCase: SejongLoginUseCase
+    
+}

--- a/RankIn/RankIn/extension/UIImage+SystemImage.swift
+++ b/RankIn/RankIn/extension/UIImage+SystemImage.swift
@@ -12,6 +12,8 @@ extension UIImage {
     enum SystemImage {
         
         case appleLogo
+        case chartBar
+        case person
         
     }
     
@@ -19,6 +21,10 @@ extension UIImage {
         switch systemImage {
         case .appleLogo:
             return UIImage(systemName: "apple.logo")!
+        case .chartBar:
+            return UIImage(systemName: "chart.bar")!
+        case .person:
+            return UIImage(systemName: "person")!
         }
     }
     

--- a/RankIn/RankIn/extension/UIViewController+Toast.swift
+++ b/RankIn/RankIn/extension/UIViewController+Toast.swift
@@ -13,16 +13,22 @@ extension UIViewController {
     enum ToastCase {
         
         case duplicatedNickname
-        case noInput
+        case noNicknameInput
+        case noGradeInput
+        case invalidGradeInput
         
     }
     
     func presentToast(toastCase: ToastCase) {
-        switch toastCase { // TODO: Toast 띄우기
+        switch toastCase {
         case .duplicatedNickname:
             self.view.makeToast("중복된 닉네임입니다\n 다른 닉네임을 입력해주세요")
-        case .noInput:
-            self.view.makeToast("닉네임을 입력해주세ㅇ")
+        case .noNicknameInput:
+            self.view.makeToast("닉네임을 입력해주세요")
+        case .noGradeInput:
+            self.view.makeToast("학점을 입력해주세요")
+        case .invalidGradeInput:
+            self.view.makeToast("소수점 두자리 까지의 형식으로 학점을 입력하세요\n예시 : 3.94")
         }
     }
     

--- a/RankIn/RankIn/extension/UIViewController+Toast.swift
+++ b/RankIn/RankIn/extension/UIViewController+Toast.swift
@@ -1,0 +1,29 @@
+//
+//  UIViewController+Toast.swift
+//  RankIn
+//
+//  Created by 조성민 on 4/17/24.
+//
+
+import UIKit
+import Toast_Swift
+
+extension UIViewController {
+    
+    enum ToastCase {
+        
+        case duplicatedNickname
+        case noInput
+        
+    }
+    
+    func presentToast(toastCase: ToastCase) {
+        switch toastCase { // TODO: Toast 띄우기
+        case .duplicatedNickname:
+            self.view.makeToast("중복된 닉네임입니다\n 다른 닉네임을 입력해주세요")
+        case .noInput:
+            self.view.makeToast("닉네임을 입력해주세ㅇ")
+        }
+    }
+    
+}


### PR DESCRIPTION
## ✅ issue_Number

#6 

# 🚀 Summary

- 메인 탭바 설정
- Auth manager 구현
- 애플 로그인 및 JWT 관리 키체인 설정
- 세종대 로그인 구현
- 닉네임 설정 구현
- 학점 설정 구현

# 🛠️ Technical Concerns 

- Auth Manager
JWT 매번 헤더에 넣어주고, 재발급이 필요한 경우를 처리하여 재발급후에 재시도를 일일이 해줘야하는 불편함이 있었습니다.
그래서 JWT 토큰의 만료와 재발급을 관리하기 위해서 Interceptor 객체를 생성했습니다. 
Alamofire에서 지원하는 adapt와 retry를 통해서 요청의 헤더에 토큰을 넣어주고, 실패시 retry를 통해서 Refresh Token으로 Access Token을 발급받아서 다시 해당 요청을 시도합니다. 

- 소셜 로그인과 JWT 관리
처음에는 JWT 토큰을 UserDefaults에 넣으면 되지 않을까 생각했습니다. UserDefaults의 내용은 info.plist에 기재되고 기록에 남기 때문에 보안과 관련이 있는 JWT 토큰을 담는 것은 올바르지 않다고 생각했습니다.
구글링을 통해서 키체인에 보관하는 방법을 채택하여 키체인의 CRUD를 총괄하는 KeyChain Manager를 구현했습니다. 
키체인에 보관하는 것은 총 3가지로 Access Token, Refresh Token, User ID 입니다.

- User ID에 대한 고찰
    - 먼저 API 호출에 user id가 포함되는 것이 맞을까? 
       API 호출 중 users/{id} 형식으로 User ID가 필요한 API 호출이 있었습니다. User ID를 포함하지 않고 JWT만으로 인증을 거치면 되지 않을까 생각했습니다.
      하지만 서버입장에서 어떤 user에 해당하는 API인지 명시하는 것이 직관적이기 때문에 User ID를 API 호출 URL에 포함하는 것이 좋다고 판단했습니다.

    - User ID의 생성의 역할이 클라이언트일까, 서버일까?
       첫 생각으로는 소셜 로그인을 통해 발급되는 User ID를 사용하는 것이 좋다고 생각했습니다. 
       그 이유는 소셜 로그인을 통해서 발급받은 유일한 값이며 어떤 소셜 로그인인지 파악할 수 있고, 클라이언트가 발급 받자마자 저장하고 서버에 넘겨주면 된다고 생각했습니다.
       하지만 이렇게 되면 위에서 URL에 User ID를 포함한다고 했었기 때문에 User ID를 노출해야 했습니다.
       그래서 소셜 로그인에서 발급받은 User ID는 DB의 User ID로 채택하지 않게 되었습니다. 

    - User ID의 생성 방법
       서버에서는 User ID를 UUID로 생성할 것이라고 했지만, 저는 반대했습니다. 
       서버의 이유는 두가지였습니다. 누군가 의도적으로 접근했을 때, 서비스 규모 파악이 불가능하고 API를 호출할 수 있는 가능성을 배재하기 위함이었습니다.
       하지만 저는 서비스 규모를 파악하는 것이 어떤 불이익이 있는지 납득하기 어려웠고, 서버 개발자들 또한 서비스 규모 파악이 서비스에 어떤 불이익이 있을지 모르겠다고 했습니다. 그저 배운 것이었습니다. 
       API 호출을 타인이 할 수 있다고 했지만 User ID가 필요한 경우 필수적으로 JWT 인증을 거쳐야 합니다. User ID는 인증의 용도가 아닌 API 호출의 직관성을 위함이기 때문에 이 또한 근거가 될 수 없다고 생각했습니다.
       만약 문제가 발생할 것이라면 지금은 연습의 단계라고 생각하여 직접 겪어보고 근거를 모아서 그 때 적용하자고 결론을 내렸습니다.
       그래서 결국 User ID는 DB의 Index로 결정했습니다.